### PR TITLE
Specify amazon_kclpy version

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends openjdk-7-jre \
     python-pip \
     && rm -rf /var/lib/apt/lists/*
 
-RUN pip install amazon_kclpy 
+RUN pip install amazon_kclpy==1.1.0
 COPY base.py /code/
 
 ONBUILD COPY . /code/


### PR DESCRIPTION
`amazon_kclpy` made a new version that has different `.jars`
